### PR TITLE
TIMER, LOGS

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -58,11 +58,11 @@ main(int argc, char *argv[]) {
   }
   sema.release();
 
-  Logger::Instance()->Init();
-  qInstallMessageHandler(Logger::LoggerMessageOutput);
   QApplication::setApplicationName("SubutaiTray");
   QApplication::setOrganizationName("subut.ai");
   QApplication app(argc, argv);
+  Logger::Instance()->Init();
+  qInstallMessageHandler(Logger::LoggerMessageOutput);
 
   if (is_first && !QApplication::arguments().contains(CCommons::RESTARTED_ARG)) {
     QMessageBox* msg_box = new QMessageBox(QMessageBox::Information, "Already running",


### PR DESCRIPTION
Found a little bug in our implementation, which can stop our timer for deleting old files. Also, we get rid of some logs:
`QObject::startTimer: Timers can only be used with threads started with QThread
QCoreApplication::applicationDirPath: Please instantiate the QApplication object first`

### Bug: 
  1. Creating a timer before app is created
  2. Accessing m_log_storage (which access applicationDirPath) before app is created
### Solution:
  1. Initializing `Logger` after app is created