### PR TITLE
Path issues

### DIFF
--- a/commons/src/OsBranchConsts.cpp
+++ b/commons/src/OsBranchConsts.cpp
@@ -322,7 +322,7 @@ template<class OS> const QString& ssh_keygen_cmd_path_internal();
 
 ssh_keygen_cmd_path_internal_def(OS_LINUX, "/usr/bin/ssh-keygen")
 ssh_keygen_cmd_path_internal_def(OS_MAC, "/usr/bin/ssh-keygen")
-ssh_keygen_cmd_path_internal_def(OS_WIN, QApplication::applicationDirPath() + QDir::separator() + "ssh-keygen.exe")
+ssh_keygen_cmd_path_internal_def(OS_WIN, "C:\\Program Files (x86)\\ssh\\ssh-keygen.exe")
 
 const QString &
 ssh_keygen_cmd_path() {  
@@ -341,7 +341,7 @@ template<class OS> const QString& ssh_cmd_path_internal();
 
 ssh_cmd_path_internal_def(OS_LINUX, "/usr/bin/ssh")
 ssh_cmd_path_internal_def(OS_MAC, "/usr/bin/ssh")
-ssh_cmd_path_internal_def(OS_WIN, QApplication::applicationDirPath() + QDir::separator() + "ssh.exe")
+ssh_cmd_path_internal_def(OS_WIN, "C:\\Program Files (x86)\\ssh\\ssh.exe")
 
 const QString &
 ssh_cmd_path() {

--- a/hub/src/SettingsManager.cpp
+++ b/hub/src/SettingsManager.cpp
@@ -273,6 +273,7 @@ CSettingsManager::CSettingsManager()
     if (CSystemCallWrapper::which(*cmd_which[i], tmp) != SCWE_SUCCESS) { // check if program in saved path is launchable
       if(CSystemCallWrapper::which(commands_name[i], tmp) != SCWE_SUCCESS) { // check if there is a `command`, which is launchable
         if(CSystemCallWrapper::which(default_values[i], tmp) != SCWE_SUCCESS) { // check if there is a program in default path
+          *cmd_which[i] = default_values[i];
           qCritical("Can not find any program to run for %s", commands_name[i].toStdString().c_str());
           continue;
         }

--- a/hub/src/SettingsManager.cpp
+++ b/hub/src/SettingsManager.cpp
@@ -265,9 +265,16 @@ CSettingsManager::CSettingsManager()
   QString tmp, symlink;
   for (int i = 0; cmd_which[i]; ++i) {
     if (*cmd_which[i] != default_values[i]) continue;
-    if (CSystemCallWrapper::which(*cmd_which[i], tmp) != SCWE_SUCCESS) continue;
-    if ((symlink = QFile::symLinkTarget(tmp)) != "") {
-      *cmd_which[i] = symlink;
+    if (CSystemCallWrapper::which(*cmd_which[i], tmp) != SCWE_SUCCESS) {
+
+    else{}
+    QFileInfo checkFile(tmp);
+    if (checkFile.isSymLink()) {
+      if ((symlink = QFile::symLinkTarget(tmp)) != "")
+        *cmd_which[i] = symlink;
+    }
+    else {
+      *cmd_which[i] = tmp;
     }
   }  
 

--- a/hub/src/SettingsManager.cpp
+++ b/hub/src/SettingsManager.cpp
@@ -261,22 +261,33 @@ CSettingsManager::CSettingsManager()
   static const QString default_values[] = {vboxmanage_command_str(),
                                            ssh_keygen_cmd_path(), ssh_cmd_path(),
                                            default_p2p_path()};
+  static const QString commands_name[] =
+                                    {"vboxmanage",
+                                     "ssh-keygen",
+                                     "ssh",
+                                     "p2p"};
 
-  QString tmp, symlink;
+
+  QString tmp;
   for (int i = 0; cmd_which[i]; ++i) {
-    if (*cmd_which[i] != default_values[i]) continue;
-    if (CSystemCallWrapper::which(*cmd_which[i], tmp) != SCWE_SUCCESS) {
+    if (CSystemCallWrapper::which(*cmd_which[i], tmp) != SCWE_SUCCESS) { // check if program in saved path is launchable
+      if(CSystemCallWrapper::which(commands_name[i], tmp) != SCWE_SUCCESS) { // check if there is a `command`, which is launchable
+        if(CSystemCallWrapper::which(default_values[i], tmp) != SCWE_SUCCESS) { // check if there is a program in default path
+          qCritical("Can not find any program to run for %s", commands_name[i].toStdString().c_str());
+          continue;
+        }
+      }
+    }
 
-    else{}
     QFileInfo checkFile(tmp);
     if (checkFile.isSymLink()) {
-      if ((symlink = QFile::symLinkTarget(tmp)) != "")
-        *cmd_which[i] = symlink;
+      *cmd_which[i] = QFile::symLinkTarget(tmp);
     }
-    else {
+    else if (*cmd_which[i] != tmp) {
       *cmd_which[i] = tmp;
     }
-  }  
+  }
+
 
   //terminal and it's arguments
   if (m_terminal_cmd == default_terminal()) {

--- a/hub/src/updater/UpdaterComponentP2P.cpp
+++ b/hub/src/updater/UpdaterComponentP2P.cpp
@@ -37,6 +37,10 @@ CUpdaterComponentP2P::p2p_path()
                                                             CSystemCallWrapper::scwe_error_to_str(cr)), DlgNotification::N_SETTINGS);
     }
   }
+  QFileInfo checkFile(p2p_path);
+  if (checkFile.isSymLink()) {
+    p2p_path = QFile::symLinkTarget(p2p_path);
+  }
   return p2p_path;
 }
 ////////////////////////////////////////////////////////////////////////////

--- a/hub/src/updater/UpdaterComponentP2P.cpp
+++ b/hub/src/updater/UpdaterComponentP2P.cpp
@@ -129,7 +129,7 @@ CUpdaterComponentP2P::update_internal() {
 void
 CUpdaterComponentP2P::update_post_action(bool success) {
   if (!success) {
-    CNotificationObserver::Instance()->Error(tr("P2P has not been updated"), DlgNotification::N_NO_ACTION);
+    CNotificationObserver::Instance()->Error(tr("P2P has not been updated. Most probably the permission is denied."), DlgNotification::N_SETTINGS);
     return;
   }
 

--- a/hub/src/updater/UpdaterComponentP2P.cpp
+++ b/hub/src/updater/UpdaterComponentP2P.cpp
@@ -38,7 +38,7 @@ CUpdaterComponentP2P::p2p_path()
     }
   }
   QFileInfo checkFile(p2p_path);
-  if (checkFile.isSymLink()) {
+  if (checkFile.exists() && checkFile.isSymLink()) {
     p2p_path = QFile::symLinkTarget(p2p_path);
   }
   return p2p_path;

--- a/hub/src/updater/UpdaterComponentTray.cpp
+++ b/hub/src/updater/UpdaterComponentTray.cpp
@@ -89,7 +89,7 @@ CUpdaterComponentTray::update_internal() {
 void
 CUpdaterComponentTray::update_post_action(bool success) {
   if (!success) {
-    CNotificationObserver::Error(tr("Tray application has not been updated"), DlgNotification::N_NO_ACTION);
+    CNotificationObserver::Error(tr("Tray application has not been updated. Most probably the permission is denied."), DlgNotification::N_SETTINGS);
     return;
   }
 


### PR DESCRIPTION
Many of path issues were because of config file which stores the settings of tray. So for example if the old path of some file was symlink and was in directory such as `/usr/bin` then tray can't replace the file in that directory because of priviliges. Same was with ssh.exe pathes in Windows. If there are no ssh.exe in Settings folder, then tray just can't use it, so tray has to find the ssh path with commands `which ssh` or `which ssh-keygen`. If it cannot find any ssh.exe, it means there is no ssh.exe in `environment variables`, so we will just set the default_path for `ssh.exe`, which is `C:/ ProgramFiles/ssh/ssh.exe`.
ISSUES: 
https://github.com/subutai-io/tray/issues/420
https://github.com/subutai-io/tray/issues/424
https://github.com/subutai-io/tray/issues/408
https://github.com/subutai-io/tray/issues/422
