### PR TITLE
refactoring restart_p2p function

### DIFF
--- a/hub/include/SystemCallWrapper.h
+++ b/hub/include/SystemCallWrapper.h
@@ -7,6 +7,12 @@
 #include <string>
 #include <vector>
 
+//give type for restart p2p
+enum restart_p2p_type{
+    UPDATED_P2P=0, //when p2p updated, stop and start
+    STOPPED_P2P //when p2p is stopped, start
+};
+
 // if you are going to change this - change method
 // CSystemCallWrapper::scwe_error_to_str(system_call_wrapper_error_t err)
 enum system_call_wrapper_error_t {
@@ -106,7 +112,7 @@ class CSystemCallWrapper {
                                                        int swarm_base_interface_id);
 
   static system_call_wrapper_error_t leave_p2p_swarm(const QString &hash);
-  static system_call_wrapper_error_t restart_p2p_service(int *res_code);
+  static system_call_wrapper_error_t restart_p2p_service(int *res_code, restart_p2p_type type);
 
   static system_call_wrapper_error_t check_container_state(const QString &hash,
                                                            const QString &ip);

--- a/hub/src/SystemCallWrapper.cpp
+++ b/hub/src/SystemCallWrapper.cpp
@@ -229,11 +229,11 @@ system_call_wrapper_error_t CSystemCallWrapper::leave_p2p_swarm(
 ////////////////////////////////////////////////////////////////////////////
 
 template <class OS>
-system_call_wrapper_error_t restart_p2p_service_internal(int *res_code);
+system_call_wrapper_error_t restart_p2p_service_internal(int *res_code,restart_p2p_type type);
 
 template <>
 system_call_wrapper_error_t restart_p2p_service_internal<Os2Type<OS_LINUX> >(
-    int *res_code) {
+    int *res_code, restart_p2p_type type) {
   *res_code = RSE_MANUAL;
 
   do {
@@ -310,14 +310,19 @@ system_call_wrapper_error_t restart_p2p_service_internal<Os2Type<OS_LINUX> >(
         break;
       }
 
-      QByteArray restart_script = QString(
+      QByteArray restart_script = type==UPDATED_P2P ? QString(
                                       "#!/bin/bash\n"
                                       "%1 disable p2p.service\n"
                                       "%1 stop p2p.service\n"
                                       "%1 enable p2p.service\n"
                                       "%1 start p2p.service\n")
                                       .arg(systemctl_path)
-                                      .toUtf8();
+                                      .toUtf8() : QString(
+                                                          "#!/bin/bash\n"
+                                                          "%1 enable p2p.service\n"
+                                                          "%1 start p2p.service\n")
+                                                          .arg(systemctl_path)
+                                                          .toUtf8();
 
       if (tmpFile.write(restart_script) != restart_script.size()) {
         QString err_msg = QString("Couldn't write restart script to temp file")
@@ -365,15 +370,16 @@ system_call_wrapper_error_t restart_p2p_service_internal<Os2Type<OS_LINUX> >(
 
 template <>
 system_call_wrapper_error_t restart_p2p_service_internal<Os2Type<OS_WIN> >(
-    int *res_code) {
+    int *res_code, restart_p2p_type type) {
   QString cmd("sc");
   QStringList args0, args1;
   args0 << "stop"
         << "\"Subutai Social P2P\"";
   args1 << "start"
         << "\"Subutai Social P2P\"";
-  system_call_res_t res =
-      CSystemCallWrapper::ssystem_th(cmd, args0, false, true);
+  system_call_res_t res;
+  if(type==UPDATED_P2P)
+      res = CSystemCallWrapper::ssystem_th(cmd, args0, false, true);
   res = CSystemCallWrapper::ssystem_th(cmd, args1, false, true);
   *res_code = RSE_SUCCESS;
   return res.res;
@@ -382,15 +388,21 @@ system_call_wrapper_error_t restart_p2p_service_internal<Os2Type<OS_WIN> >(
 
 template <>
 system_call_wrapper_error_t restart_p2p_service_internal<Os2Type<OS_MAC> >(
-    int *res_code) {
+    int *res_code, restart_p2p_type type) {
   QString cmd("osascript");
   QStringList args;
-  args << "-e"
-       << "do shell script \"launchctl unload "
-          "/Library/LaunchDaemons/io.subutai.p2p.daemon.plist;"
-          " launchctl load /Library/LaunchDaemons/io.subutai.p2p.daemon.plist\""
-          " with administrator privileges";
+  type == UPDATED_P2P ?
+      args << "-e"
+           << "do shell script \"launchctl unload "
+              "/Library/LaunchDaemons/io.subutai.p2p.daemon.plist;"
+              " launchctl load /Library/LaunchDaemons/io.subutai.p2p.daemon.plist\""
+              " with administrator privileges" :
+      args << "-e"
+           << "do shell script \"launchctl load"
+              "/Library/LaunchDaemons/io.subutai.p2p.daemon.plist\""
+              " with administrator privileges";
   system_call_res_t res =
+
       CSystemCallWrapper::ssystem_th(cmd, args, false, true);
   *res_code = RSE_SUCCESS;
   return res.res;
@@ -398,8 +410,8 @@ system_call_wrapper_error_t restart_p2p_service_internal<Os2Type<OS_MAC> >(
 /*************************/
 
 system_call_wrapper_error_t CSystemCallWrapper::restart_p2p_service(
-    int *res_code) {
-  return restart_p2p_service_internal<Os2Type<CURRENT_OS> >(res_code);
+    int *res_code, restart_p2p_type type) {
+  return restart_p2p_service_internal<Os2Type<CURRENT_OS> >(res_code, type);
 }
 ////////////////////////////////////////////////////////////////////////////
 

--- a/hub/src/SystemCallWrapper.cpp
+++ b/hub/src/SystemCallWrapper.cpp
@@ -374,13 +374,13 @@ system_call_wrapper_error_t restart_p2p_service_internal<Os2Type<OS_WIN> >(
   QString cmd("sc");
   QStringList args0, args1;
   args0 << "stop"
-        << "\"Subutai Social P2P\"";
+        << "Subutai P2P";
   args1 << "start"
-        << "\"Subutai Social P2P\"";
+        << "Subutai P2P";
   system_call_res_t res;
   if(type==UPDATED_P2P)
-      res = CSystemCallWrapper::ssystem_th(cmd, args0, false, true);
-  res = CSystemCallWrapper::ssystem_th(cmd, args1, false, true);
+      res = CSystemCallWrapper::ssystem_th(cmd, args0, true, true);
+  res = CSystemCallWrapper::ssystem_th(cmd, args1, true, true);
   *res_code = RSE_SUCCESS;
   return res.res;
 }
@@ -398,12 +398,12 @@ system_call_wrapper_error_t restart_p2p_service_internal<Os2Type<OS_MAC> >(
               " launchctl load /Library/LaunchDaemons/io.subutai.p2p.daemon.plist\""
               " with administrator privileges" :
       args << "-e"
-           << "do shell script \"launchctl load"
+           << "do shell script \"launchctl load "
               "/Library/LaunchDaemons/io.subutai.p2p.daemon.plist\""
               " with administrator privileges";
   system_call_res_t res =
 
-      CSystemCallWrapper::ssystem_th(cmd, args, false, true);
+      CSystemCallWrapper::ssystem_th(cmd, args, true, true);
   *res_code = RSE_SUCCESS;
   return res.res;
 }

--- a/hub/src/TrayControlWindow.cpp
+++ b/hub/src/TrayControlWindow.cpp
@@ -530,7 +530,7 @@ void TrayControlWindow::launch_p2p(){
                                     arg(current_branch_name()).arg(p2p_package_url()), DlgNotification::N_SETTINGS);
         break;
     case P2PStatus_checker::P2P_READY :
-        CSystemCallWrapper::restart_p2p_service(&rse_err);
+        CSystemCallWrapper::restart_p2p_service(&rse_err, restart_p2p_type::STOPPED_P2P);
         if (rse_err == 0)
             CNotificationObserver::Instance()->Info(tr("Trying to launch P2P, wait 15 seconds"), DlgNotification::N_NO_ACTION);
         else

--- a/hub/src/updater/UpdaterComponentP2P.cpp
+++ b/hub/src/updater/UpdaterComponentP2P.cpp
@@ -146,7 +146,7 @@ CUpdaterComponentP2P::update_post_action(bool success) {
   int rse_err = 0;
 
   system_call_wrapper_error_t scwe =
-      CSystemCallWrapper::restart_p2p_service(&rse_err);
+      CSystemCallWrapper::restart_p2p_service(&rse_err,restart_p2p_type::UPDATED_P2P);
 
   if (scwe != SCWE_SUCCESS) {
     CNotificationObserver::Instance()->Error(tr("p2p post update failed. err : %1").


### PR DESCRIPTION
* now has two options:
1)stop p2p - > start p2p (after p2p updated you need to restart)
2)start p2p (when p2p is stopped you need to just start, no loop launching)
* refactored for OSWindows, now working properly